### PR TITLE
📝 Change hostname to host

### DIFF
--- a/mod.ts
+++ b/mod.ts
@@ -1,6 +1,6 @@
 /** Check if a website is up */
 export async function isUp(url: string): Promise<boolean> {
-  const hostname = encodeURIComponent((new URL(url)).hostname);
+  const host = encodeURIComponent((new URL(url)).host);
   const result: {
     "domain": string;
     "port": number;
@@ -8,7 +8,7 @@ export async function isUp(url: string): Promise<boolean> {
     "response_ip": string;
     "response_code": number;
     "response_time": number;
-  } = await (await fetch(`https://isitup.org/${hostname}.json`))
+  } = await (await fetch(`https://isitup.org/${host}.json`))
     .json();
   return result.status_code === 1;
 }

--- a/mod_test.ts
+++ b/mod_test.ts
@@ -10,3 +10,13 @@ Deno.test("should be down", async (): Promise<void> => {
     false,
   );
 });
+
+/**
+ * The official website of deno is: https://deno.land/
+ * Website remote address: 172.67.163.168:443
+ * The official website of Deno does not allow users to access content through IP addresses, 
+ * but in some cases, I may need this method to test my personal server.
+ */
+Deno.test("deno remote address test", async (): Promise<void> => {
+  assertEquals(await isUp("http://172.67.163.168:443"), true);
+})


### PR DESCRIPTION
In some cases, I may need to test whether my personal server is down.

So I think it's more accurate to use host to replace hostname。

The reference is [https://developer.mozilla.org/en-US/docs/Web/API/Location/host](https://developer.mozilla.org/en-US/docs/Web/API/Location/host).

> The host property of the Location interface is a USVString containing the host, that is the hostname, and then, if the port of the URL is nonempty, a ':', and the port of the URL.

Test cases have been added.